### PR TITLE
Set Lava as the default Starknet RPC url

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The plugin requires the following environment variables:
 ```typescript
 STARKNET_ADDRESS = your_starknet_address;
 STARKNET_PRIVATE_KEY = your_private_key;
-STARKNET_RPC_URL = your_rpc_url;
+STARKNET_RPC_URL = your_rpc_url;  // e.g. https://rpc.starknet.lava.build
 ```
 
 ## Actions

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -1,7 +1,7 @@
 import type { IAgentRuntime } from "@elizaos/core";
 import { z } from "zod";
 
-const STARKNET_PUBLIC_RPC = "https://starknet-mainnet.public.blastapi.io";
+const STARKNET_PUBLIC_RPC = "https://rpc.starknet.lava.build";
 
 export const starknetEnvSchema = z.object({
     STARKNET_ADDRESS: z.string().min(1, "Starknet address is required"),


### PR DESCRIPTION
**Relates to**
N/A

**Risks**
Low

**Background / What does this PR do?**
This PR updates the default RPC URLs to use Lava.

**What kind of change is this?**
Improvements (configuration changes)

**Documentation changes needed?**
My changes do not require a change to the project documentation.

**Discord username**
@rod_of_nim

**Email address**
[nimrod@magmadevs.com](mailto:nimrod@magmadevs.com)


<div align="center">
  <h1>
    <a href="https://lavanet.xyz">
      <img src="https://user-images.githubusercontent.com/2770565/223762290-44afc792-8ad4-4dbb-b2c2-532780d6c5de.png" alt="Lava Network" width="30" height="25">
      Lava Network
    </a>
  </h1>
</div>
